### PR TITLE
Fix schema label struct

### DIFF
--- a/src/components/about/OrgBookData.vue
+++ b/src/components/about/OrgBookData.vue
@@ -47,6 +47,7 @@
 <script lang="ts">
 import i18n from "@/i18n";
 import { ICredentialType } from "@/interfaces/api/v2/credential-type.interface";
+import { unwrapTranslations } from "@/utils/entity";
 import { Component, Vue } from "vue-property-decorator";
 import { mapGetters } from "vuex";
 
@@ -58,7 +59,7 @@ import { mapGetters } from "vuex";
 export default class OrgBookData extends Vue {
   formattedDescription(type: ICredentialType): string {
     return (
-      type.schema_label?.translations?.[i18n.locale]?.description ||
+      unwrapTranslations(type.schema_label)?.[i18n.locale]?.description ||
       type?.description ||
       ""
     );

--- a/src/components/about/OrgBookData.vue
+++ b/src/components/about/OrgBookData.vue
@@ -59,6 +59,7 @@ import { mapGetters } from "vuex";
 export default class OrgBookData extends Vue {
   formattedDescription(type: ICredentialType): string {
     return (
+      // TODO: change to type.schema_label?.[i18n.locale]?.description after update to backend
       unwrapTranslations(type.schema_label)?.[i18n.locale]?.description ||
       type?.description ||
       ""

--- a/src/components/contact/ContactForm.vue
+++ b/src/components/contact/ContactForm.vue
@@ -123,6 +123,7 @@ import router from "@/router";
 import { ICredentialType } from "@/interfaces/api/v2/credential-type.interface";
 import { IContactRequest } from "@/interfaces/api/v4/contact.interface";
 import { contactReason } from "@/store/modules/contact";
+import { unwrapTranslations } from "@/utils/entity";
 
 interface Data {
   formData: {
@@ -163,8 +164,13 @@ export default class ContactForm extends Vue {
 
   get formattedCredentialTypes(): Array<{ text: string; value: number }> {
     return this.credentialTypes.map((type) => ({
-      text: type.schema_label?.translations?.[this.$i18n.locale]?.label
-        ? type.schema_label.translations[this.$i18n.locale].label
+      text: unwrapTranslations(type.schema_label)?.[this.$i18n.locale]?.label
+        ? (
+            unwrapTranslations(type.schema_label) as Record<
+              string,
+              { label: string; description: string }
+            >
+          )[this.$i18n.locale].label
         : type.description,
       value: type.id,
     }));

--- a/src/components/contact/ContactForm.vue
+++ b/src/components/contact/ContactForm.vue
@@ -164,6 +164,7 @@ export default class ContactForm extends Vue {
 
   get formattedCredentialTypes(): Array<{ text: string; value: number }> {
     return this.credentialTypes.map((type) => ({
+      // TODO: remove unwrap translations functions after backend update
       text: unwrapTranslations(type.schema_label)?.[this.$i18n.locale]?.label
         ? (
             unwrapTranslations(type.schema_label) as Record<

--- a/src/components/entity/credentialDetail/CredentialDetail.vue
+++ b/src/components/entity/credentialDetail/CredentialDetail.vue
@@ -150,6 +150,7 @@ import i18n from "@/i18n/index";
 import router from "@/router";
 import moment from "moment";
 import BackTo from "@/components/shared/BackTo.vue";
+import { unwrapTranslations } from "@/utils/entity";
 
 interface Data {
   headers: Record<string, string>[];
@@ -233,14 +234,15 @@ export default class CredentialDetail extends Vue {
     }
     let credDesc = this.getSelectedCredential.credential_type.description;
     if (
-      this.getSelectedCredential.credential_type.schema_label?.translations?.[
-        i18n.locale
-      ]?.label
+      unwrapTranslations(
+        this.getSelectedCredential.credential_type.schema_label
+      )?.[i18n.locale]?.label
     ) {
-      credDesc =
-        this.getSelectedCredential.credential_type.schema_label.translations[
-          i18n.locale
-        ].label;
+      credDesc = (
+        unwrapTranslations(
+          this.getSelectedCredential.credential_type.schema_label
+        ) as Record<string, { label: string; description: string }>
+      )[i18n.locale].label;
     }
     return credDesc;
   }

--- a/src/interfaces/api/v2/credential-type.interface.ts
+++ b/src/interfaces/api/v2/credential-type.interface.ts
@@ -14,6 +14,7 @@ export interface ICredentialType extends IApiResource {
   issuer: IIssuer;
   credential_title?: string;
   highlighted_attributes?: string[];
+  // TODO: remove ISchemaLabel type after backend update
   schema_label?:
     | ISchemaLabel
     | Record<string, { label: string; description: string }>;

--- a/src/interfaces/api/v2/credential-type.interface.ts
+++ b/src/interfaces/api/v2/credential-type.interface.ts
@@ -14,7 +14,9 @@ export interface ICredentialType extends IApiResource {
   issuer: IIssuer;
   credential_title?: string;
   highlighted_attributes?: string[];
-  schema_label?: ISchemaLabel;
+  schema_label?:
+    | ISchemaLabel
+    | Record<string, { label: string; description: string }>;
   claim_labels?: Record<string, Record<string, string>>;
 }
 

--- a/src/interfaces/api/v4/credential.interface.ts
+++ b/src/interfaces/api/v4/credential.interface.ts
@@ -18,6 +18,7 @@ export interface ICredentialAttribute {
   value: string | number | boolean;
 }
 
+// TODO: remove ISchemaLabel after schema structure update to backend
 export interface ISchemaLabel {
   translations: Record<string, { label: string; description: string }>;
 }

--- a/src/interfaces/api/v4/credential.interface.ts
+++ b/src/interfaces/api/v4/credential.interface.ts
@@ -51,7 +51,7 @@ export interface ICredentialDisplayType {
   relationship_types?: string[];
   credential_title?: string;
   highlighted_attributes?: string[];
-  schema_label?: ISchemaLabel;
+  schema_label?: Record<string, { label: string; description: string }>;
   attributes?: ICredentialAttribute[];
   credential_type_id: number;
 }

--- a/src/store/modules/entity.ts
+++ b/src/store/modules/entity.ts
@@ -108,8 +108,8 @@ const actions = {
     const filterFields: IEntityFacetField[] = [];
     creds.forEach((cred) => {
       let credDesc = cred.credential_type;
-      if (cred.schema_label?.translations?.[i18n.locale]?.label) {
-        credDesc = cred.schema_label.translations[i18n.locale].label;
+      if (cred.schema_label?.[i18n.locale]?.label) {
+        credDesc = cred.schema_label[i18n.locale].label;
       }
       const idx = filterFields.map((field) => field.value).indexOf(credDesc);
       if (idx >= 0) {

--- a/src/store/modules/search.ts
+++ b/src/store/modules/search.ts
@@ -31,6 +31,7 @@ import {
 import { objHasProp } from "@/utils/general";
 import { ICredentialType } from "@/interfaces/api/v2/credential-type.interface";
 import i18n from "@/i18n/index";
+import { unwrapTranslations } from "@/utils/entity";
 
 const v4SearchService = new v4Search();
 const v3SearchService = new v3Search();
@@ -118,8 +119,13 @@ const getters = {
           (type: ICredentialType) => type.id.toString() === filter?.value
         );
         let retVal = credDesc.description || "";
-        if (credDesc.schema_label?.translations?.[i18n.locale]?.label) {
-          retVal = credDesc.schema_label.translations[i18n.locale].label;
+        if (unwrapTranslations(credDesc.schema_label)?.[i18n.locale]?.label) {
+          retVal = (
+            unwrapTranslations(credDesc.schema_label) as Record<
+              string,
+              { label: string; description: string }
+            >
+          )[i18n.locale].label;
         }
         return retVal;
       },

--- a/src/store/modules/search.ts
+++ b/src/store/modules/search.ts
@@ -119,6 +119,7 @@ const getters = {
           (type: ICredentialType) => type.id.toString() === filter?.value
         );
         let retVal = credDesc.description || "";
+        // TODO: remove unwrapTranslations after backend update
         if (unwrapTranslations(credDesc.schema_label)?.[i18n.locale]?.label) {
           retVal = (
             unwrapTranslations(credDesc.schema_label) as Record<

--- a/src/utils/entity.ts
+++ b/src/utils/entity.ts
@@ -49,6 +49,7 @@ export function getRelationshipIssuer(
   )?.credential_type?.issuer;
 }
 
+// TODO: remove after backend update
 export function unwrapTranslations(
   label:
     | ISchemaLabel
@@ -98,6 +99,7 @@ export function credOrRelationshipToDisplay(
     display.revoked = credItem.revoked;
     display.revoked_date = credItem.revoked_date;
     display.value = credItem.names[0]?.text;
+    // TODO: remove unwrap func after backend update
     display.schema_label = unwrapTranslations(
       credItem.credential_type.schema_label
     );
@@ -131,6 +133,7 @@ export function credOrRelationshipToDisplay(
     display.revoked_date = relItem.credential.revoked_date;
     display.relationship_types = relItem.attributes.map((attr) => attr.value);
     display.value = getRelationshipName(relItem);
+    // TODO: remove unwrap func after backend update
     display.schema_label = unwrapTranslations(
       relItem.credential.credential_type.schema_label
     );

--- a/src/utils/entity.ts
+++ b/src/utils/entity.ts
@@ -4,6 +4,7 @@ import {
   ICredential,
   ICredentialDisplayType,
   ICredentialAttribute,
+  ISchemaLabel,
 } from "@/interfaces/api/v4/credential.interface";
 import { IEntityFilter } from "@/interfaces/entity-filter.interface";
 import { selectFirstAttrItem } from "@/utils/attribute";
@@ -48,6 +49,22 @@ export function getRelationshipIssuer(
   )?.credential_type?.issuer;
 }
 
+export function unwrapTranslations(
+  label:
+    | ISchemaLabel
+    | Record<string, { label: string; description: string }>
+    | undefined
+): Record<string, { label: string; description: string }> | undefined {
+  if (label?.translations) {
+    return label.translations as
+      | Record<string, { label: string; description: string }>
+      | undefined;
+  }
+  return label as
+    | Record<string, { label: string; description: string }>
+    | undefined;
+}
+
 export function credOrRelationshipToDisplay(
   item: ICredential | IRelationship,
   credSet?: ICredential[]
@@ -81,7 +98,9 @@ export function credOrRelationshipToDisplay(
     display.revoked = credItem.revoked;
     display.revoked_date = credItem.revoked_date;
     display.value = credItem.names[0]?.text;
-    display.schema_label = credItem.credential_type.schema_label;
+    display.schema_label = unwrapTranslations(
+      credItem.credential_type.schema_label
+    );
     display.highlighted_attributes = getHighlightedAttributes(
       credItem,
       credItem.credential_type.credential_title,
@@ -112,7 +131,9 @@ export function credOrRelationshipToDisplay(
     display.revoked_date = relItem.credential.revoked_date;
     display.relationship_types = relItem.attributes.map((attr) => attr.value);
     display.value = getRelationshipName(relItem);
-    display.schema_label = relItem.credential.credential_type.schema_label;
+    display.schema_label = unwrapTranslations(
+      relItem.credential.credential_type.schema_label
+    );
     display.highlighted_attributes = getHighlightedAttributes(
       relItem,
       relItem.credential.credential_type.credential_title,
@@ -148,8 +169,8 @@ export function isEntityFilterActive(
 export function getCredentialLabel(cred: ICredentialDisplayType): string {
   let credDesc = cred.credential_type;
   const locale = i18n.locale;
-  if (cred.schema_label?.translations?.[locale]?.label) {
-    credDesc = cred.schema_label.translations[locale].label;
+  if (cred.schema_label?.[locale]?.label) {
+    credDesc = cred.schema_label[locale].label;
   }
   return credDesc;
 }


### PR DESCRIPTION
In preparation for resolving issue https://github.com/bcgov/aries-vcr/issues/725 we need to make sure the frontend supports both types of schema labels `{"translations":{"en":{"labels":"string", "description":"string"}}}` and `{"en":{"labels":"string", "description":"string"}}` otherwise making a change to the backend structure would break the frontend functionality.