### PR TITLE
Fix owned by link bug

### DIFF
--- a/src/components/entity/CredentialItem.vue
+++ b/src/components/entity/CredentialItem.vue
@@ -134,9 +134,7 @@ export default class CredentialItem extends Vue {
   }
 
   get sourceId(): string {
-    const { sourceId } = this.cred?.rel_id
-      ? { sourceId: this.cred.rel_id }
-      : this.$route.params;
+    const { sourceId } = this.$route.params;
     return sourceId;
   }
 


### PR DESCRIPTION
Fixed a minor bug marking relationship credentials as owned by the related entity.

The link to a relationship credential verification page would be `http://orgbook.gov.bc.ca/entity/<related_topic_sourceid>/credential/3130` when it should be `http://orgbook.gov.bc.ca/entity/<topic_sourceid>/credential/3130`
