### PR TITLE
created expired vs replaced

### DIFF
--- a/src/components/entity/CredentialItem.vue
+++ b/src/components/entity/CredentialItem.vue
@@ -90,6 +90,7 @@ import { dateFilter } from "@/filters/date.filter";
 import { IFormattedTopic } from "@/interfaces/api/v2/topic.interface";
 import { ICredentialType } from "@/interfaces/api/v2/credential-type.interface";
 import { TranslateResult } from "vue-i18n";
+import { isExpired } from "@/utils/entity";
 
 @Component({
   computed: {
@@ -117,6 +118,8 @@ export default class CredentialItem extends Vue {
 
   credentialTypes!: ICredentialType[];
 
+  isExpired = isExpired;
+
   get getAuthorityLink(): string | URL {
     return this.cred ? this.cred.authorityLink : this.authorityLink;
   }
@@ -126,7 +129,9 @@ export default class CredentialItem extends Vue {
   }
 
   get getCredRevoked(): boolean {
-    return this.cred ? this.cred.revoked : this.expired;
+    return this.cred
+      ? this.cred.revoked || !!this.isExpired(this.cred.attributes)
+      : this.expired;
   }
 
   get getCredId(): number {

--- a/src/components/entity/EntityResult.vue
+++ b/src/components/entity/EntityResult.vue
@@ -158,7 +158,7 @@
                 "
                 class="expired-credential"
               >
-                Expired:
+                Replaced:
                 {{
                   businessAsRelationship[i + relationshipStartIndex].credential
                     .revoked_date | formatDate
@@ -389,7 +389,14 @@
                         <template #header>
                           <div class="text-body-2">
                             <div v-if="cred.revoked" class="expired-credential">
-                              Expired: {{ cred.revoked_date | formatDate }}
+                              Replaced: {{ cred.revoked_date | formatDate }}
+                            </div>
+                            <div
+                              v-else-if="isExpired(cred.attributes)"
+                              class="expired-credential"
+                            >
+                              Expired:
+                              {{ isExpired(cred.attributes) | formatDate }}
                             </div>
                             <div
                               v-if="cred.registration_reason"
@@ -441,6 +448,7 @@ import { selectFirstAttrItem } from "@/utils/attribute";
 import {
   getRelationshipName,
   credOrRelationshipToDisplay,
+  isExpired,
   getCredentialLabel,
 } from "@/utils/entity";
 import BackTo from "@/components/shared/BackTo.vue";
@@ -550,6 +558,7 @@ export default class EntityResult extends Vue {
   ];
   getRelationshipName = getRelationshipName;
   getCredentialLabel = getCredentialLabel;
+  isExpired = isExpired;
 
   data(): Data {
     return {
@@ -654,7 +663,9 @@ export default class EntityResult extends Vue {
   ): Array<ICredentialDisplayType> {
     var filteredCreds = [...creds];
     if (!this.getEntityFilters.show_expired) {
-      filteredCreds = creds.filter((cred) => !cred.revoked);
+      filteredCreds = creds.filter(
+        (cred) => !cred.revoked && !this.isExpired(cred.attributes)
+      );
     }
     return filteredCreds;
   }

--- a/src/utils/entity.ts
+++ b/src/utils/entity.ts
@@ -25,6 +25,12 @@ export function getHighlightedAttributes(
   return highlighted;
 }
 
+export function isExpired(attrs: ICredentialAttribute[] | undefined): string {
+  const date = selectFirstAttrItem({ key: "type", value: "expiry_date" }, attrs)
+    ?.value as string | undefined;
+  return date && Date.now() > new Date(date).getTime() ? date : "";
+}
+
 export function getRelationshipName(relationship: IRelationship): string {
   let ret = "";
   const relNameLength = relationship?.related_topic?.names?.length;


### PR DESCRIPTION
Created notion of expired and replaced credentials:
Replaced: revoked by issuer
Expired: credential has an `expiry_date` attribute before the current date
Both Expired and Replaced are treated the same by filters and the credential detail view, except for wording
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>