### PR TITLE
removed link if issuer does not have a url

### DIFF
--- a/src/components/entity/CredentialItem.vue
+++ b/src/components/entity/CredentialItem.vue
@@ -33,10 +33,11 @@
         <div :class="{ 'pb-3': timeline && !highlightedAttr.length }">
           <div class="font-weight-bold">Authority</div>
           <div>
-            <a :href="getAuthorityLink">
+            <a v-if="getAuthorityLink" :href="getAuthorityLink">
               <span>{{ getAuthority }}</span>
               <v-icon small class="fake-link">{{ mdiOpenInNew }}</v-icon>
             </a>
+            <span v-else>{{ getAuthority }}</span>
           </div>
         </div>
 


### PR DESCRIPTION
Removed link and icon from credential authority section if issuer does not have a URL attribute:
## Without Issuer URL set:
![image](https://user-images.githubusercontent.com/36937407/159993478-232cff06-e997-4b5f-9a77-bd795ab5ef32.png)
## With Issuer URL set:
![image](https://user-images.githubusercontent.com/36937407/159993564-e3dee5b8-f06a-490a-892e-7a79c605160d.png)
Resolves: #160
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>