### PR TITLE
fix: Fix entity display bn

### DIFF
--- a/src/components/entity/EntityResult.vue
+++ b/src/components/entity/EntityResult.vue
@@ -814,7 +814,8 @@ export default class EntityResult extends Vue {
   get entityBusinessNumber(): string | undefined {
     return selectFirstAttrItem(
       { key: "type", value: "business_number" },
-      this.entityCredentials?.map((cred) => {
+      // find the latest business number
+      this.entityCredentials?.filter(cred => cred.latest)?.map((cred) => {
         return {
           type: cred.type,
           text: cred.value,
@@ -858,7 +859,7 @@ export default class EntityResult extends Vue {
 
     var fullCredentials: ICredentialDisplayType[] = [];
     this.selectedTopicFullCredentialSet.forEach((credSet) => {
-      //filter out all the raltionship credentials
+      //filter out all the relationship credentials
       fullCredentials.push(
         ...credSet.credentials
           .filter((cred) => !this.isRelationshipCred(cred))

--- a/src/components/entity/EntityResult.vue
+++ b/src/components/entity/EntityResult.vue
@@ -815,12 +815,14 @@ export default class EntityResult extends Vue {
     return selectFirstAttrItem(
       { key: "type", value: "business_number" },
       // find the latest business number
-      this.entityCredentials?.filter(cred => cred.latest)?.map((cred) => {
-        return {
-          type: cred.type,
-          text: cred.value,
-        };
-      })
+      this.entityCredentials
+        ?.filter((cred) => cred.latest)
+        ?.map((cred) => {
+          return {
+            type: cred.type,
+            text: cred.value,
+          };
+        })
     )?.text as string;
   }
 

--- a/src/components/entity/filter/EntityFilterFacetPanel.vue
+++ b/src/components/entity/filter/EntityFilterFacetPanel.vue
@@ -4,7 +4,11 @@
       <slot name="title">{{ title }}</slot>
     </v-expansion-panel-header>
     <v-expansion-panel-content>
-      <EntityFilterFacets :entityType="entityType" :filterField="filterField" :fields="fields" />
+      <EntityFilterFacets
+        :entityType="entityType"
+        :filterField="filterField"
+        :fields="fields"
+      />
       <template v-if="more.length">
         <span
           class="flex-row flex-align-items-center justify-center fake-link"

--- a/src/components/entity/filter/EntityFilterFacets.vue
+++ b/src/components/entity/filter/EntityFilterFacets.vue
@@ -29,7 +29,10 @@
               class="checkbox"
             ></v-simple-checkbox>
           </v-list-item-action>
-          <v-list-item-content class="pt-1 pb-1" v-translate="toTranslationFormat(field.value, entityType)">
+          <v-list-item-content
+            class="pt-1 pb-1"
+            v-translate="toTranslationFormat(field.value, entityType)"
+          >
           </v-list-item-content>
           <v-list-item-action class="d-flex justify-end mt-1 mb-1">
             <div>{{ field.count }}</div>

--- a/src/i18n/translate.ts
+++ b/src/i18n/translate.ts
@@ -1,37 +1,43 @@
 import { DirectiveFunction } from "vue";
 import { DirectiveBinding } from "vue/types/options";
-import VueI18n from "."
+import VueI18n from ".";
 
-export const translate: DirectiveFunction = (el: Element, binding: DirectiveBinding) => {
-    el.textContent = $translate(binding.value)
-}
+export const translate: DirectiveFunction = (
+  el: Element,
+  binding: DirectiveBinding
+) => {
+  el.textContent = $translate(binding.value);
+};
 
 // Uses the entity_type as well as the registration description to lookup translations for entries from the LEAR database
 export const $translate = (value: string): string => {
-    const messages = VueI18n.messages
-    const locale = VueI18n.locale
-    const bindingValues = value.split(".")
-    let transReturn
-    // try old translation first
-    if (bindingValues.length >= 2) {
-        const translationAttempt = (messages[locale][bindingValues[0]] as { [key: string]: string | any })?.[bindingValues[1]]
-        if (typeof (translationAttempt) === "string") {
-            transReturn = translationAttempt
+  const messages = VueI18n.messages;
+  const locale = VueI18n.locale;
+  const bindingValues = value.split(".");
+  let transReturn;
+  // try old translation first
+  if (bindingValues.length >= 2) {
+    const translationAttempt = (
+      messages[locale][bindingValues[0]] as { [key: string]: string | any }
+    )?.[bindingValues[1]];
+    if (typeof translationAttempt === "string") {
+      transReturn = translationAttempt;
+    } else {
+      // we know we're working with an entity from LEAR
+      const description =
+        translationAttempt?.displayName ?? translationAttempt?.title;
+      if (typeof description === "string") {
+        transReturn = description;
+      } else if (typeof description !== "undefined") {
+        // we are working with a description object, indexed by entity type: BC, SP, etc.
+        if (bindingValues.length >= 3) {
+          // if entity type is passed in as a binding value
+          transReturn = description[bindingValues[2]];
         } else {
-            // we know we're working with an entity from LEAR
-            const description = translationAttempt?.displayName ?? translationAttempt?.title
-            if (typeof (description) === "string") {
-                transReturn = description
-            } else if (typeof (description) !== "undefined") {
-                // we are working with a description object, indexed by entity type: BC, SP, etc.
-                if (bindingValues.length >= 3) {
-                    // if entity type is passed in as a binding value
-                    transReturn = description[bindingValues[2]]
-                } else {
-                    transReturn = translationAttempt?.title
-                }
-            }
+          transReturn = translationAttempt?.title;
         }
+      }
     }
-    return transReturn ?? value
-}
+  }
+  return transReturn ?? value;
+};

--- a/src/interfaces/api/v4/credential.interface.ts
+++ b/src/interfaces/api/v4/credential.interface.ts
@@ -42,6 +42,7 @@ export interface ICredentialDisplayType {
   id: number;
   credential_type: string;
   rel_id?: string;
+  latest?: boolean;
   type: string;
   authority: string;
   authorityLink: string | URL;

--- a/src/utils/entity.ts
+++ b/src/utils/entity.ts
@@ -14,16 +14,16 @@ export function isCredential(item: ICredential | IRelationship): boolean {
   return (item as ICredential)?.credential_type !== undefined;
 }
 
-// Used to append entity_type to the suffix of the string. This is needed to work with 
+// Used to append entity_type to the suffix of the string. This is needed to work with
 // entries from the LEAR database
 export function toTranslationFormat(base: string, entityType?: string): string {
   if (entityType) {
-    const entityTypeSplit = entityType.split('.')
+    const entityTypeSplit = entityType.split(".");
     if (entityTypeSplit.length >= 2) {
-      return base + "." + entityTypeSplit[1]
+      return base + "." + entityTypeSplit[1];
     }
   }
-  return base
+  return base;
 }
 
 export function getHighlightedAttributes(

--- a/src/utils/entity.ts
+++ b/src/utils/entity.ts
@@ -102,6 +102,7 @@ export function credOrRelationshipToDisplay(
   if (isCredential(item)) {
     const credItem = item as ICredential;
     display.id = credItem.id;
+    display.latest = credItem.latest;
     display.authority = credItem.credential_type.issuer.name;
     display.authorityLink = credItem.credential_type.issuer.url;
     display.type = credItem.names[0]?.type;


### PR DESCRIPTION
Organizations with updated business numbers had the old business number displaying on the entity details page.
This change fixes the functionality to display the latest business number.

![image](https://user-images.githubusercontent.com/36937407/225156408-5f352da1-4bf0-4555-a4a0-c4d7f05db0da.png)


Resolves: https://github.com/bcgov/orgbook-bc-client/issues/175