### PR TITLE
Fix permissions issue with Caddy image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,3 +13,8 @@ RUN npm run build
 # production stage
 FROM ${runtime_image} as production-stage
 COPY --from=build-stage /app/dist /srv
+
+# Fix permissions issue with Caddy image
+# - Between version 2.6.2 and 2.6.3 there were some permissions changes on the official images that stopped them from working on OpenShift.
+# - This update resolves that permissions issue for OCP.
+RUN chown 1001:root /usr/bin/caddy


### PR DESCRIPTION
- Between version 2.6.2 and 2.6.3 there were some permissions changes on the official images that stopped them from working on OpenShift.
- These updates resolve the permissions issue for OCP.