### PR TITLE
Updated orgbook_api.md to include data licensing terms and conditions

### DIFF
--- a/src/docs/orgbook_api.md
+++ b/src/docs/orgbook_api.md
@@ -12,4 +12,6 @@ Anyone is able to use OrgBook BC data in their own services. Rather than needing
 
 Developers can review the [API specification](http://orgbook.gov.bc.ca/api/) and the [API documentation](https://github.com/bcgov/orgbook-bc-api-docs). There is also an [API demo](https://stackblitz.com/edit/angular-ivy-rjbxsj) for developers to see it in action.
 
+The data published in OrgBook BC is provided under the [Access Only Data Terms and Conditions](https://bcgov.github.io/data-publication/pages/faq.html#data-publication-licensing-options---open-dataaccess-only).
+
 If you have any questions about the API or its potential, [get in touch](/contact) with our team.


### PR DESCRIPTION
updated the content for the [orgbook-api](https://orgbook.gov.bc.ca/about/orgbook-api) page to include data licensing terms and conditions and direct link to the page explaining them.