### PR TITLE
Quick fix for relationships redirecting users to the home page

### DIFF
--- a/src/components/entity/EntityResult.vue
+++ b/src/components/entity/EntityResult.vue
@@ -42,7 +42,7 @@
           :authority="entityRegistrationIssuer"
           :authorityLink="entityRegistrationIssuerUrl"
           :effectiveDate="entityStatusEffectiveDate"
-          :credId="entityNameCredId"
+          :credentialId="entityNameCredId"
         >
           <template #header>
             <div class="text-h6 font-weight-bold">Registration</div>
@@ -148,7 +148,7 @@
             businessAsRelationship[i + relationshipStartIndex].credential
               .effective_date
           "
-          :credId="
+          :credentialId="
             businessAsRelationship[i + relationshipStartIndex].credential.id
           "
         >
@@ -177,7 +177,7 @@
                       .related_topic &&
                     businessAsRelationship[i + relationshipStartIndex]
                       .related_topic.source_id
-                  }`"
+                  }/type/registration.registries.ca`"
                   class="font-weight-bold"
                   >{{
                     getRelationshipName(
@@ -288,7 +288,7 @@
           v-for="(_, i) in ownedByRelationship"
           :key="i"
           :entityType="entityJurisdiction"
-          :cred="credOrRelationshipToDisplay(ownedByRelationship[i], credSet)"
+          :credential="credOrRelationshipToDisplay(ownedByRelationship[i], credSet)"
           :disableDefaultHeader="true"
           :effectiveDate="ownedByRelationship[i].credential.effective_date"
         >
@@ -308,7 +308,7 @@
                 :to="`/entity/${
                   ownedByRelationship[i].related_topic &&
                   ownedByRelationship[i].related_topic.source_id
-                }`"
+                }/type/registration.registries.ca`"
                 class="font-weight-bold"
               >
                 {{ getRelationshipName(ownedByRelationship[i]) }}

--- a/src/components/entity/filter/EntityFilterChips.vue
+++ b/src/components/entity/filter/EntityFilterChips.vue
@@ -36,8 +36,8 @@ export default {
       getEntityFilters: "getEntityFilters",
       mdiClose: "mdiClose"
     }),
-    get activeEntityFilters(): EntityChips[] {
-      var chips: EntityChips[] = [];
+    activeEntityFilters: function (): EntityChips[] {
+      let chips: EntityChips[] = [];
       Object.keys(this.getEntityFilters).forEach((key) => {
         if (Array.isArray(this.getEntityFilters[key])) {
           chips.push(


### PR DESCRIPTION
In reference to this issue @ianco noticed

> There is some weirdness with the OrgBook links. For example one of the companies I am looking at is https://orgbook.gov.bc.ca/entity/BC1518413/type/registration.registries.ca, and it has 4 DBA's, which are linked from the parent company like this: https://orgbook.gov.bc.ca/entity/FM1038301. However OrgBook doesn't like this and is expecting the link to have the /type/registration.registries.ca post-fix, like this: https://orgbook.gov.bc.ca/entity/FM1038301/type/registration.registries.ca





> Has OrgBook changed recently? I'm not sure why the /type/... is required but is not included in the relationship links generated on the parent company's page.
NONE of the relationship links in OrgBook work, they all re-direct to the home page

This seems to have been an existing issue dating back to before the migration. Only required some property renames to resolve it