### PR TITLE
Add support for both old and new style entity links

### DIFF
--- a/src/components/entity/EntityResult.vue
+++ b/src/components/entity/EntityResult.vue
@@ -177,7 +177,7 @@
                       .related_topic &&
                     businessAsRelationship[i + relationshipStartIndex]
                       .related_topic.source_id
-                  }/type/registration.registries.ca`"
+                  }`"
                   class="font-weight-bold"
                   >{{
                     getRelationshipName(
@@ -308,7 +308,7 @@
                 :to="`/entity/${
                   ownedByRelationship[i].related_topic &&
                   ownedByRelationship[i].related_topic.source_id
-                }/type/registration.registries.ca`"
+                }`"
                 class="font-weight-bold"
               >
                 {{ getRelationshipName(ownedByRelationship[i]) }}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -11,6 +11,10 @@ const routes: Array<RouteConfig> = [
     component: Search,
   },
   {
+    path: "/entity/:sourceId",
+    redirect: "/entity/:sourceId/type/registration.registries.ca",
+  },
+  {
     path: "/entity/:sourceId/type/:type",
     name: "Entity",
     component: () =>


### PR DESCRIPTION
This PR resolves #258 

This removes the need for appending the the routes as we did in #257 we now redirect all old links `/entity/:sourceId` to the new `/entity/:sourceId/type/registration.registries.ca` 

![screencast-250122-1055-23](https://github.com/user-attachments/assets/8bed685b-7a62-46e2-aa04-550ecaa416c8)
